### PR TITLE
Avoid NPE on events for unmapped IGC types

### DIFF
--- a/adapter/src/main/java/org/odpi/egeria/connectors/ibm/igc/repositoryconnector/IGCOMRSMetadataCollection.java
+++ b/adapter/src/main/java/org/odpi/egeria/connectors/ibm/igc/repositoryconnector/IGCOMRSMetadataCollection.java
@@ -3738,6 +3738,9 @@ public class IGCOMRSMetadataCollection extends OMRSMetadataCollectionBase {
 
         List<EntityMapping> mappers = entityMappingStore.getMappingsByIgcAssetType(igcAssetType);
 
+        if (mappers == null) {
+            mappers = new ArrayList<>();
+        }
         if (mappers.isEmpty()) {
             EntityMapping defaultMapper = entityMappingStore.getDefaultEntityMapper();
             if (defaultMapper != null) {


### PR DESCRIPTION
~~Whenever no other mapping for an IGC type is defined, it will default to mapping via a `Referenceable`.~~